### PR TITLE
Add Gentoo installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Add this line to your hyprland.conf
 exec-once = /usr/bin/hyprland-per-window-layout
 ```
 
+## Install on Gentoo
+
+Activate wayland overlay as described in [README](https://github.com/bsd-ac/wayland-desktop#activate-overlay-via-eselect-repository), allow **~amd64** keyword and then install it:
+
+```bash
+# emerge --ask gui-apps/hyprland-per-window-layout
+```
+
 ## Configuration
 
 Optional, please read [configuration.md](configuration.md) for more details.


### PR DESCRIPTION
## Description

Follow these steps to install hyprland-per-window-layout on Gentoo Linux

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

It was installed by me using described method and going to be be [merged](https://github.com/bsd-ac/wayland-desktop/pull/76) soon