### PR TITLE
fix: parse keyboard variant

### DIFF
--- a/src/hyprland_event.rs
+++ b/src/hyprland_event.rs
@@ -105,26 +105,24 @@ pub fn event(name: &str, data: &str, options: &Options) {
 
     if name == "activelayout" {
         // params ex: keychron-keychron-k2,English (US)
-        let params: Vec<&str> = data.split(",").collect();
-        if params.len() == 2 {
-            if params[0].contains("wlr_virtual_keyboard_v") {
-                log::debug!("Skip virtual keyboard {}", params[0]);
+        // params ex with variant: at-translated-set-2-keyboard,English (US, intl., with dead keys)
+        if let Some((param_keyboard, param_layout)) = data.split_once(',') {
+            if param_keyboard.contains("wlr_virtual_keyboard_v") {
+                log::debug!("Skip virtual keyboard {}", param_keyboard);
                 return;
             }
             log::debug!(
                 "Catch layout changed event on {} with {}",
-                params[0],
-                params[1]
+                param_keyboard,
+                param_layout
             );
-            // add keyboard from params[0] to KEYBOARDS
-            fullfill_keyboards_list(params[0].to_string());
-            fullfill_layouts_list(params[1].to_string());
+            fullfill_keyboards_list(param_keyboard.to_string());
+            fullfill_layouts_list(param_layout.to_string());
 
-            // save layout from params[1] as index of the global layouts
             let layout_vec = LAYOUTS.lock().unwrap();
             let mut index = 0;
             for layout in layout_vec.iter() {
-                if params[1].eq(&layout.to_string()) {
+                if param_layout.eq(&layout.to_string()) {
                     let active_layout: u16 = *ACTIVE_LAYOUT.lock().unwrap();
                     if active_layout == index {
                         log::debug!("Layout {} is current", layout);
@@ -150,7 +148,6 @@ pub fn event(name: &str, data: &str, options: &Options) {
         } else {
             log::warn!("Bad 'activelayout' format: {}", data)
         }
-        return;
     }
 }
 #[derive(Debug)]


### PR DESCRIPTION
## Description

Fixes #15 
This PR fixes the application not handling keyboard layout variants as expected.

While investigating the events emitted by Hyprland, I identified the cause of the issue. The event is the same for changing layouts (`activelayout`), but variants add commas to the layout name:
```
[2024-02-23T17:18:20Z DEBUG hyprland_per_window_layout::hyprland_event] E:'activelayout' D:'at-translated-set-2-keyboard,English (US, intl., with dead keys)'
[2024-02-23T17:18:20Z WARN  hyprland_per_window_layout::hyprland_event] Bad 'activelayout' format: at-translated-set-2-keyboard,English (US, intl., with dead keys)
```

This causes [this check to fail:](https://github.com/coffebar/hyprland-per-window-layout/commit/f18c51c53ead8ce6ec7f1eb3c46dec379b14c5b1#diff-bdf7c4b44940c3610496537e21138d1b0fb3e1d13ea1f44764ea24052c6076c2R108-R109)
```
let params: Vec<&str> = data.split(",").collect();
if params.len() == 2 {
```

So to fix it all I had to do was change from `split` to `split_once`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I tested with the following keyboard configuration on my hyprland.conf:
```
kb_layout = us,us
kb_variant = ,intl
kb_options = grp:win_space_toggle,caps:swapescape
kb_model =
kb_rules =
```
I also tested without variants:
``` 
kb_layout = us,br
# kb_variant = ,intl
kb_options = grp:win_space_toggle,caps:swapescape
kb_model =
kb_rules =
```
With both configs, changing keyboard layout and active window resulted in the expected behavior.

### Possibly breaking?

The only way I can imagine this PR breaking is if hyprlctl emits an `activelayout` event with more than 2 parameters. During my tests this never happened, but if we discover (or if @coffebar already knows) that there can be more than 2 parameters, I can improve the parsing to split by commas while ignoring commas inside parentheses, which would work for US-intl, but I'm not sure if this would cover every keyboard variant. 