### PR TITLE
Exit endless loop

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,8 @@ fn listen(socket_addr: String) -> std::io::Result<()> {
     loop {
         // read message from socket
         let mut buf: Vec<u8> = vec![];
-        reader.read_until(b'\n', &mut buf).unwrap();
+        let readed = reader.read_until(b'\n', &mut buf).unwrap();
+        if readed == 0 { break Ok(()); }
         let data = String::from_utf8_lossy(&buf);
         let data_parts: Vec<&str> = data.trim().split(">>").collect();
         if data_parts.len() > 1 {


### PR DESCRIPTION
## Description

For some reason hyprland don't kills hyprland-per-window-layout. It leads to endless loop that consumes all CPU. It's possibly very rare or specific for me, but loop should be exited anyway

Fixes some notes from #14

## Type of change

- [X] Bug fix

## How Has This Been Tested?

Exited Hyprland and no sawd running utility
